### PR TITLE
Wrap campaign API link with config URL helper

### DIFF
--- a/static/generator/dashboard_generator.html
+++ b/static/generator/dashboard_generator.html
@@ -638,7 +638,7 @@
                                     <p>Canal: ${campaign.channel || 'Prográmatica'} | Key: ${campaign.key}</p>
                                 </div>
                                 <div class="campaign-actions">
-                                    <a href="${campaign.api_endpoint.replace('/data', '')}" class="button button-secondary" target="_blank">📊 Ver API</a>
+                                    <a href="${CONFIG.getApiUrl(campaign.api_endpoint.replace('/data', ''))}" class="button button-secondary" target="_blank">📊 Ver API</a>
                                     <a href="${CONFIG.getDashboardUrl(`/static/dash_${campaign.slug}.html`)}" class="button button-primary" target="_blank">🎬 Dashboard</a>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- update the campaign API link to use CONFIG.getApiUrl for consistent base URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5965fdcb08323aabd4784800c9b30