### PR TITLE
Atualiza leitura de métricas no dashboard genérico

### DIFF
--- a/cloud_run_app.py
+++ b/cloud_run_app.py
@@ -631,6 +631,15 @@ def get_campaign_data(campaign_key):
                 data = fallback_data
         
         if data:
+            metrics_data = data.get("metrics")
+            if not metrics_data and data.get("total_metrics"):
+                metrics_data = data.get("total_metrics") or {}
+                # Garantir que os templates sempre encontrem a chave "metrics"
+                if isinstance(data, dict):
+                    data["metrics"] = metrics_data
+            if not metrics_data:
+                metrics_data = {}
+
             return jsonify({
                 "success": True,
                 "data": {
@@ -641,20 +650,20 @@ def get_campaign_data(campaign_key):
                     "period": data.get("period", "15/09/2025 - 30/09/2025"),
                     "metrics": {
                         "budget_contracted": data.get("budget_contracted", 31000),
-                        "spend": data.get("metrics", {}).get("spend", 0),
-                        "impressions": data.get("metrics", {}).get("impressions", 0),
+                        "spend": metrics_data.get("spend", 0),
+                        "impressions": metrics_data.get("impressions", 0),
                         "impressions_contracted": 193750,  # Valor contratado
-                        "clicks": data.get("metrics", {}).get("clicks", 0),
-                        "ctr": data.get("metrics", {}).get("ctr", 0),
-                        "q100": data.get("metrics", {}).get("q100", 0),
-                        "starts": data.get("metrics", {}).get("starts", 0),
-                        "vtr": data.get("metrics", {}).get("vtr", 0),
-                        "cpv": data.get("metrics", {}).get("cpv", 0),
-                        "cpm": data.get("metrics", {}).get("cpm", 0),
-                        "pacing": data.get("metrics", {}).get("pacing", 0),
-                        "vc_contracted": data.get("metrics", {}).get("vc_contracted", 0),
-                        "vc_delivered": data.get("metrics", {}).get("vc_delivered", 0),
-                        "vc_pacing": data.get("metrics", {}).get("vc_pacing", 0)
+                        "clicks": metrics_data.get("clicks", 0),
+                        "ctr": metrics_data.get("ctr", 0),
+                        "q100": metrics_data.get("q100", 0),
+                        "starts": metrics_data.get("starts", 0),
+                        "vtr": metrics_data.get("vtr", 0),
+                        "cpv": metrics_data.get("cpv", 0),
+                        "cpm": metrics_data.get("cpm", 0),
+                        "pacing": metrics_data.get("pacing", metrics_data.get("vc_pacing", 0)),
+                        "vc_contracted": metrics_data.get("vc_contracted", 0),
+                        "vc_delivered": metrics_data.get("vc_delivered", metrics_data.get("q100", 0)),
+                        "vc_pacing": metrics_data.get("vc_pacing", metrics_data.get("pacing", 0))
                     },
                     "daily_data": data.get("daily_data", []),
                     "per_data": data.get("per_data", []),

--- a/static/generator/templates/dash_generic.html
+++ b/static/generator/templates/dash_generic.html
@@ -175,6 +175,7 @@
 class DashboardLoader {
     constructor(campaignKey) {
         this.campaignKey = campaignKey;
+        this.data = null;
         // Usar Cloud Run diretamente para máxima confiabilidade
         this.apiEndpoint = `{{API_ENDPOINT}}`;
         this.loadingSteps = [
@@ -377,6 +378,7 @@ class DashboardLoader {
 
     renderDashboard(data) {
         // Renderizar dados diretamente no HTML existente
+        this.data = data || {};
         this.renderMetrics(data);
         this.renderCharts(data);
         this.renderTables(data);
@@ -387,8 +389,12 @@ class DashboardLoader {
     renderMetrics(data) {
         // Renderizar métricas principais
         const metricsContainer = document.getElementById('metrics-overview-top');
-        if (metricsContainer && data.campaign_summary) {
-            const summary = data.campaign_summary;
+        if (!metricsContainer) {
+            return;
+        }
+
+        const summary = this.getCampaignSummary(data);
+        if (summary) {
             metricsContainer.innerHTML = `
                 <div class="metric">
                     <div class="label">💰 Investimento</div>
@@ -407,6 +413,8 @@ class DashboardLoader {
                     <div class="value">R$ ${this.formatCurrency(summary.cpv || 0)}</div>
                 </div>
             `;
+        } else {
+            metricsContainer.innerHTML = '';
         }
     }
 
@@ -414,17 +422,18 @@ class DashboardLoader {
         // Renderizar gráficos básicos
         const spendCtx = document.getElementById('chartSpendShare');
         const resultsCtx = document.getElementById('chartResults');
-        
-        if (spendCtx && data.campaign_summary) {
+
+        const summary = this.getCampaignSummary(data);
+
+        if (spendCtx && summary) {
+            const totalSpend = summary.total_spend || 0;
+            const remaining = Math.max((summary.investment || 0) - totalSpend, 0);
             new Chart(spendCtx, {
                 type: 'doughnut',
                 data: {
                     labels: ['Utilizado', 'Restante'],
                     datasets: [{
-                        data: [
-                            data.campaign_summary.total_spend || 0,
-                            (data.campaign_summary.investment || 0) - (data.campaign_summary.total_spend || 0)
-                        ],
+                        data: [totalSpend, remaining],
                         backgroundColor: ['#8B5CF6', '#EC4899']
                     }]
                 },
@@ -438,8 +447,8 @@ class DashboardLoader {
                 }
             });
         }
-        
-        if (resultsCtx && data.campaign_summary) {
+
+        if (resultsCtx && summary) {
             new Chart(resultsCtx, {
                 type: 'bar',
                 data: {
@@ -447,9 +456,9 @@ class DashboardLoader {
                     datasets: [{
                         label: 'Performance',
                         data: [
-                            data.campaign_summary.total_impressions || 0,
-                            data.campaign_summary.total_clicks || 0,
-                            data.campaign_summary.total_video_completions || 0
+                            summary.total_impressions || 0,
+                            summary.total_clicks || 0,
+                            summary.total_video_completions || 0
                         ],
                         backgroundColor: ['#8B5CF6', '#EC4899', '#10B981']
                     }]
@@ -523,6 +532,85 @@ class DashboardLoader {
         });
     }
 
+    getCampaignSummary(data) {
+        if (!data) {
+            return null;
+        }
+
+        if (data.campaign_summary) {
+            return data.campaign_summary;
+        }
+
+        const contract = data.contract || {};
+        const metrics = data.metrics || data.total_metrics || {};
+        const hasData = (contract && Object.keys(contract).length > 0) || (metrics && Object.keys(metrics).length > 0);
+
+        if (!hasData) {
+            return null;
+        }
+
+        const investment = this.toNumber(
+            contract.investment ??
+            metrics.investment ??
+            metrics.budget_contracted ??
+            data.budget_contracted ??
+            contract.budget ??
+            0
+        );
+
+        const totalSpend = this.toNumber(
+            metrics.total_spend ??
+            metrics.spend ??
+            metrics.budget_used ??
+            contract.budget_used ??
+            0
+        );
+
+        const totalImpressions = this.toNumber(
+            metrics.total_impressions ??
+            metrics.impressions ??
+            metrics.impressoes ??
+            0
+        );
+
+        const totalClicks = this.toNumber(
+            metrics.total_clicks ??
+            metrics.clicks ??
+            metrics.cliques ??
+            0
+        );
+
+        const totalVideoCompletions = this.toNumber(
+            metrics.total_video_completions ??
+            metrics.vc_delivered ??
+            metrics.q100 ??
+            metrics.video_completions ??
+            0
+        );
+
+        return {
+            investment,
+            complete_views_contracted: this.toNumber(
+                contract.complete_views_contracted ??
+                metrics.vc_contracted ??
+                data.vc_contracted ??
+                0
+            ),
+            pacing: this.toNumber(metrics.pacing ?? metrics.vc_pacing ?? contract.pacing ?? 0),
+            cpv: this.toNumber(
+                metrics.cpv ??
+                contract.cpv ??
+                contract.cpv_contracted ??
+                data.cpv ??
+                0
+            ),
+            total_spend: totalSpend,
+            total_impressions: totalImpressions,
+            total_clicks: totalClicks,
+            total_video_completions: totalVideoCompletions
+        };
+    }
+
     // Funções auxiliares de formatação
     formatCurrency(value) {
         return new Intl.NumberFormat('pt-BR', {
@@ -540,15 +628,24 @@ class DashboardLoader {
     formatPercentage(value) {
         return `${(value || 0).toFixed(2)}%`;
     }
+
+    toNumber(value) {
+        if (value === null || value === undefined || value === '') {
+            return 0;
+        }
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
 }
 
 // Inicializar dashboard quando a página carregar
 document.addEventListener('DOMContentLoaded', () => {
     // Extrair campaign key da URL ou usar padrão
     let campaignKey = '{{CAMPAIGN_KEY}}';
-    
+
     // Criar e carregar dashboard
     const dashboard = new DashboardLoader(campaignKey);
+    window.dashboardLoader = dashboard;
     dashboard.loadDashboard();
 });
 </script>


### PR DESCRIPTION
## Summary
- ajusta o template genérico para calcular o resumo da campanha a partir de `contract` e `metrics`, evitando dependências de `campaign_summary`
- garante que o endpoint do Cloud Run exponha os dados de `total_metrics` também em `metrics`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d59b9ce0e4832380340d9b1c916051