### PR TITLE
Aggregate fallback daily data by publisher

### DIFF
--- a/static/generator/processors/test_video_campaign_data.py
+++ b/static/generator/processors/test_video_campaign_data.py
@@ -70,6 +70,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-17",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher A",
                 "spend": 1087.36,
                 "impressions": 10036,
                 "clicks": 5,
@@ -85,6 +86,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-18",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher A",
                 "spend": 673.92,
                 "impressions": 6514,
                 "clicks": 0,
@@ -100,6 +102,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-19",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher B",
                 "spend": 1511.68,
                 "impressions": 11609,
                 "clicks": 1,
@@ -115,6 +118,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-20",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher C",
                 "spend": 346.40,
                 "impressions": 3130,
                 "clicks": 2,
@@ -130,6 +134,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-21",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher C",
                 "spend": 230.40,
                 "impressions": 1757,
                 "clicks": 0,
@@ -145,6 +150,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-22",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher D",
                 "spend": 2577.44,
                 "impressions": 19936,
                 "clicks": 32,
@@ -160,6 +166,7 @@ def create_test_data(campaign_config: CampaignConfig) -> Dict[str, Any]:
             {
                 "date": "2025-09-23",
                 "creative": f"Creative {campaign_config.client} 30s_V1.mp4",
+                "publisher": "Publisher E",
                 "spend": 5488.32,
                 "impressions": 41184,
                 "clicks": 2,

--- a/static/generator/templates/dash_generic.html
+++ b/static/generator/templates/dash_generic.html
@@ -491,14 +491,14 @@ class DashboardLoader {
         if (tbodyChannels && data.publishers) {
             tbodyChannels.innerHTML = data.publishers.map(publisher => `
                 <tr>
-                    <td>${publisher.publisher || publisher.name || 'N/A'}</td>
-                    <td>R$ ${this.formatCurrency(publisher.investimento || publisher.budget || 0)}</td>
-                    <td>R$ ${this.formatCurrency(publisher.investimento || publisher.spend || 0)}</td>
+                    <td>${publisher.name || publisher.publisher || 'N/A'}</td>
+                    <td>R$ ${this.formatCurrency(publisher.budget_contracted || publisher.budget || 0)}</td>
+                    <td>R$ ${this.formatCurrency(publisher.spend || 0)}</td>
                     <td>${this.formatPercentage(publisher.pacing || 0)}</td>
-                    <td>${this.formatNumber(publisher.impressoes || publisher.impressions || 0)}</td>
-                    <td>${this.formatNumber(publisher.cliques || publisher.clicks || 0)}</td>
+                    <td>${this.formatNumber(publisher.impressions || 0)}</td>
+                    <td>${this.formatNumber(publisher.clicks || 0)}</td>
                     <td>${this.formatPercentage(publisher.ctr || 0)}</td>
-                    <td>${this.formatNumber(publisher.visualizacoes_completas || publisher.video_completions || 0)}</td>
+                    <td>${this.formatNumber(publisher.vc_delivered || publisher.q100 || 0)}</td>
                     <td>${this.formatPercentage(publisher.vtr || 0)}</td>
                     <td>R$ ${this.formatCurrency(publisher.cpv || 0)}</td>
                     <td>R$ ${this.formatCurrency(publisher.cpm || 0)}</td>


### PR DESCRIPTION
## Summary
- add helper utilities and aggregation logic in `cloud_run_app` to build publisher-level metrics when using fallback data
- enrich test video campaign fixtures with publisher identifiers to support aggregation
- update dashboard template to read the new backend metric field names for publisher rows

## Testing
- python - <<'PY'
import os
import sys
sys.path.append(os.path.join(os.getcwd(), 'static/generator/processors'))
sys.path.append(os.path.join(os.getcwd(), 'static/generator/config'))

from campaign_config import CAMPAIGNS
from test_video_campaign_data import create_test_data
from cloud_run_app import aggregate_daily_data_by_publisher

config = CAMPAIGNS["sebrae_pr"]
data = create_test_data(config)
agg, totals = aggregate_daily_data_by_publisher(data["daily_data"], data["contract"]["investment"])
print("Aggregated entries:")
for entry in agg:
    print(entry)
print("\nPublisher totals:")
for name, metrics in totals.items():
    print(name, metrics)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d5a87f644c8323b85e30a0f41da61d