### PR TITLE
Fix API link generation for campaign data

### DIFF
--- a/static/generator/dashboard_generator.html
+++ b/static/generator/dashboard_generator.html
@@ -638,7 +638,7 @@
                                     <p>Canal: ${campaign.channel || 'Prográmatica'} | Key: ${campaign.key}</p>
                                 </div>
                                 <div class="campaign-actions">
-                                    <a href="${CONFIG.getApiUrl(campaign.api_endpoint.replace('/data', ''))}" class="button button-secondary" target="_blank">📊 Ver API</a>
+                                    <a href="${CONFIG.getApiUrl(campaign.api_endpoint)}" class="button button-secondary" target="_blank">📊 Ver API</a>
                                     <a href="${CONFIG.getDashboardUrl(`/static/dash_${campaign.slug}.html`)}" class="button button-primary" target="_blank">🎬 Dashboard</a>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- build the campaign API link with the full endpoint so the data path is preserved when opening the Cloud Run service

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5b6d8b5a883238e51b0df18fe1051