### PR TITLE
Improve numeric parsing consistency

### DIFF
--- a/cloud_run_app.py
+++ b/cloud_run_app.py
@@ -21,6 +21,8 @@ from html import escape
 sys.path.append('static/generator/processors')
 sys.path.append('static/generator/config')
 
+from numeric_parsers import safe_float as parse_safe_float, safe_int as parse_safe_int
+
 # Configurar logging primeiro
 logging.basicConfig(
     level=logging.INFO,
@@ -65,48 +67,14 @@ def add_cors_headers(response):
 
 def _safe_float(value):
     """Converter valores para float de forma resiliente"""
-    if value is None:
-        return 0.0
 
-    try:
-        if isinstance(value, (int, float)):
-            return float(value)
-
-        value_str = str(value).strip()
-        if not value_str:
-            return 0.0
-
-        value_str = value_str.replace('R$', '').replace(' ', '')
-        if ',' in value_str:
-            value_str = value_str.replace('.', '').replace(',', '.')
-
-        return float(value_str)
-    except (ValueError, TypeError):
-        return 0.0
+    return parse_safe_float(value)
 
 
 def _safe_int(value):
     """Converter valores para int de forma resiliente"""
-    if value is None:
-        return 0
 
-    try:
-        if isinstance(value, int):
-            return value
-        if isinstance(value, float):
-            return int(value)
-
-        value_str = str(value).strip()
-        if not value_str:
-            return 0
-
-        value_str = value_str.replace('R$', '').replace(' ', '')
-        if ',' in value_str:
-            value_str = value_str.replace('.', '').replace(',', '.')
-
-        return int(float(value_str))
-    except (ValueError, TypeError):
-        return 0
+    return parse_safe_int(value)
 
 
 def _normalize_name(name):

--- a/static/generator/processors/numeric_parsers.py
+++ b/static/generator/processors/numeric_parsers.py
@@ -1,0 +1,138 @@
+"""Utilities for parsing numeric values from localized strings."""
+
+import math
+import re
+from typing import Optional, Union
+
+NumericInput = Union[str, int, float]
+
+_NUMERIC_EXTRACT_PATTERN = re.compile(r"[^0-9,\.\-]+")
+_SEPARATOR_PATTERN = re.compile(r"[\.,]")
+_DIGIT_PATTERN = re.compile(r"[^0-9]")
+
+
+def _normalize_input(value: NumericInput) -> Optional[str]:
+    """Return a trimmed string representation of *value* or ``None`` if empty."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+            return None
+        return str(value)
+
+    text = str(value).strip()
+    if not text or text.lower() == "nan":
+        return None
+
+    # Normalise minus symbol variations
+    text = text.replace("−", "-")
+    return text
+
+
+def _extract_sign(value: str) -> tuple[str, str]:
+    """Return the sign (``"-"`` or ``""``) and the unsigned remainder of *value*."""
+
+    sign = ""
+    if value.startswith("-"):
+        sign = "-"
+        value = value[1:]
+
+    # Remove any additional minus signs that may appear mid-string
+    value = value.replace("-", "")
+    return sign, value
+
+
+def normalise_numeric_string(value: NumericInput) -> Optional[str]:
+    """Convert *value* to a numeric string with ``."` as decimal separator.
+
+    Thousands separators and currency symbols are removed. If no digits are
+    found the function returns ``None``.
+    """
+
+    text = _normalize_input(value)
+    if text is None:
+        return None
+
+    sign, unsigned = _extract_sign(text)
+    unsigned = _NUMERIC_EXTRACT_PATTERN.sub("", unsigned)
+    if not unsigned:
+        return None
+
+    digits_only = _DIGIT_PATTERN.sub("", unsigned)
+    if not digits_only:
+        return None
+
+    separators = list(_SEPARATOR_PATTERN.finditer(unsigned))
+    if not separators:
+        return f"{sign}{digits_only}"
+
+    last_sep = separators[-1]
+    decimal_sep = last_sep.group()
+    integer_part_raw = unsigned[: last_sep.start()]
+    decimal_part_raw = unsigned[last_sep.start() + 1 :]
+
+    integer_digits = _DIGIT_PATTERN.sub("", integer_part_raw)
+    decimal_digits = _DIGIT_PATTERN.sub("", decimal_part_raw)
+
+    treat_as_decimal = bool(decimal_digits)
+
+    if treat_as_decimal:
+        if decimal_sep == "." and "," not in unsigned:
+            # Heuristic: patterns like 193.750 are thousands with three trailing digits.
+            if len(decimal_digits) == 3 and len(integer_digits) > 2:
+                treat_as_decimal = False
+        elif decimal_sep == "," and "." not in unsigned:
+            if len(decimal_digits) == 3 and len(integer_digits) > 2:
+                treat_as_decimal = False
+
+    if treat_as_decimal:
+        return f"{sign}{integer_digits}.{decimal_digits}"
+
+    return f"{sign}{digits_only}"
+
+
+def safe_float(value: NumericInput) -> float:
+    """Robust float conversion that handles currency and thousand separators."""
+
+    if value is None:
+        return 0.0
+
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+            return 0.0
+        return float(value)
+
+    normalised = normalise_numeric_string(value)
+    if not normalised:
+        return 0.0
+
+    try:
+        return float(normalised)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def safe_int(value: NumericInput) -> int:
+    """Robust integer conversion that mirrors :func:`safe_float`."""
+
+    if value is None:
+        return 0
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return 0
+        return int(value)
+
+    normalised = normalise_numeric_string(value)
+    if not normalised:
+        return 0
+
+    try:
+        return int(float(normalised))
+    except (TypeError, ValueError):
+        return 0

--- a/static/generator/processors/working_video_extractor.py
+++ b/static/generator/processors/working_video_extractor.py
@@ -16,6 +16,7 @@ import re
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from google_sheets_service import GoogleSheetsService
+from numeric_parsers import safe_float as parse_safe_float, safe_int as parse_safe_int
 
 logger = logging.getLogger(__name__)
 
@@ -441,21 +442,17 @@ class WorkingVideoExtractor:
     
     def _safe_float(self, value) -> float:
         """Converter valor para float de forma segura"""
-        try:
-            if pd.isna(value) or value == '' or value == 'nan':
-                return 0.0
-            return float(str(value).replace(',', '.'))
-        except (ValueError, TypeError):
+
+        if hasattr(pd, "isna") and pd.isna(value):
             return 0.0
-    
+        return parse_safe_float(value)
+
     def _safe_int(self, value) -> int:
         """Converter valor para int de forma segura"""
-        try:
-            if pd.isna(value) or value == '' or value == 'nan':
-                return 0
-            return int(float(str(value).replace(',', '.')))
-        except (ValueError, TypeError):
+
+        if hasattr(pd, "isna") and pd.isna(value):
             return 0
+        return parse_safe_int(value)
 
 def extract_campaign_data(campaign_key: str) -> Optional[Dict[str, Any]]:
     """Função principal para extrair dados de uma campanha - VERSÃO QUE FUNCIONA"""
@@ -834,21 +831,17 @@ class WorkingVideoExtractor:
     
     def _safe_float(self, value) -> float:
         """Converter valor para float de forma segura"""
-        try:
-            if pd.isna(value) or value == '' or value == 'nan':
-                return 0.0
-            return float(str(value).replace(',', '.'))
-        except (ValueError, TypeError):
+
+        if hasattr(pd, "isna") and pd.isna(value):
             return 0.0
-    
+        return parse_safe_float(value)
+
     def _safe_int(self, value) -> int:
         """Converter valor para int de forma segura"""
-        try:
-            if pd.isna(value) or value == '' or value == 'nan':
-                return 0
-            return int(float(str(value).replace(',', '.')))
-        except (ValueError, TypeError):
+
+        if hasattr(pd, "isna") and pd.isna(value):
             return 0
+        return parse_safe_int(value)
 
 def extract_campaign_data(campaign_key: str) -> Optional[Dict[str, Any]]:
     """Função principal para extrair dados de uma campanha - VERSÃO QUE FUNCIONA"""


### PR DESCRIPTION
## Summary
- add a shared numeric_parsers helper to strip currency symbols and thousand separators before applying decimal normalization
- update working_video_extractor and cloud_run_app to reuse the shared numeric parsing logic for consistent float/int conversions

## Testing
- python - <<'PY'  # sanity-check numeric normalisation
- python -m compileall static/generator/processors/numeric_parsers.py cloud_run_app.py static/generator/processors/working_video_extractor.py


------
https://chatgpt.com/codex/tasks/task_e_68d5c346f88083239e4981e3e4d9f79a