### PR TITLE
Improve daily data date handling

### DIFF
--- a/static/generator/templates/dash_generic.html
+++ b/static/generator/templates/dash_generic.html
@@ -605,8 +605,15 @@ class DashboardLoader {
                 record && record.reference_date
             );
 
+            const parsedTimestamp = this.parseDateValue(date);
+            const normalizedDate = Number.isFinite(parsedTimestamp)
+                ? this.formatDateFromTimestamp(parsedTimestamp)
+                : null;
+
             return {
-                date: date || '',
+                date: normalizedDate || date || '',
+                rawDate: date || '',
+                timestamp: Number.isFinite(parsedTimestamp) ? parsedTimestamp : null,
                 spend: Number.isFinite(spend) ? spend : null,
                 impressions: Number.isFinite(impressions) ? impressions : null,
                 clicks: Number.isFinite(clicks) ? clicks : null,
@@ -619,11 +626,23 @@ class DashboardLoader {
         });
 
         rows.sort((a, b) => {
-            if (a.date && b.date) {
-                return String(a.date).localeCompare(String(b.date));
+            const timeA = Number.isFinite(a.timestamp) ? a.timestamp : null;
+            const timeB = Number.isFinite(b.timestamp) ? b.timestamp : null;
+
+            if (timeA !== null && timeB !== null) {
+                return timeA - timeB;
             }
-            if (a.date) return -1;
-            if (b.date) return 1;
+            if (timeA !== null) return -1;
+            if (timeB !== null) return 1;
+
+            const textA = a.rawDate || a.date;
+            const textB = b.rawDate || b.date;
+
+            if (textA && textB) {
+                return String(textA).localeCompare(String(textB));
+            }
+            if (textA) return -1;
+            if (textB) return 1;
             return 0;
         });
 
@@ -1262,6 +1281,61 @@ class DashboardLoader {
             return Number.isFinite(parsed) ? parsed : null;
         }
         return null;
+    }
+
+    parseDateValue(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+
+        if (value instanceof Date) {
+            const timestamp = value.getTime();
+            return Number.isFinite(timestamp) ? timestamp : null;
+        }
+
+        if (typeof value === 'number') {
+            return Number.isFinite(value) ? value : null;
+        }
+
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        const normalized = trimmed
+            .replace(/\s+/g, ' ')
+            .trim();
+
+        const brDateMatch = normalized.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+        if (brDateMatch) {
+            const day = brDateMatch[1].padStart(2, '0');
+            const month = brDateMatch[2].padStart(2, '0');
+            const year = brDateMatch[3];
+            const isoLike = `${year}-${month}-${day}`;
+            const parsed = Date.parse(isoLike);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+
+        const parsed = Date.parse(normalized);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    formatDateFromTimestamp(timestamp) {
+        if (!Number.isFinite(timestamp)) {
+            return null;
+        }
+        const date = new Date(timestamp);
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+            return null;
+        }
+        const year = date.getUTCFullYear();
+        const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(date.getUTCDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
     }
 
     setupEventListeners() {


### PR DESCRIPTION
## Summary
- normalize daily channel dates using a shared parser that supports ISO and DD/MM/AAAA formats
- fall back to lexical comparison only when parsing fails to keep chronological ordering intact
- expose a helper to format parsed timestamps so the table displays consistent ISO dates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5decaad148323b367ffe1dee07fe0