### PR TITLE
Fix daily VTR calculation to use completions

### DIFF
--- a/static/generator/processors/working_video_extractor.py
+++ b/static/generator/processors/working_video_extractor.py
@@ -453,7 +453,10 @@ class WorkingVideoExtractor:
                     
                     # Calcular métricas derivadas
                     cpm = (spend / impressions * 1000) if impressions > 0 else 0
-                    vtr = (starts / impressions * 100) if impressions > 0 else 0
+                    if starts > 0:
+                        vtr = (q100 / starts) * 100
+                    else:
+                        vtr = 0
                     
                     record = {
                         "date": date_str,


### PR DESCRIPTION
## Summary
- update the daily VTR computation to divide 100% views by starts while keeping the zero-starts fallback

## Testing
- PYTHONPATH=static/generator/processors python - <<'PY'
import pandas as pd
from types import SimpleNamespace
from static.generator.processors.working_video_extractor import WorkingVideoExtractor

config = SimpleNamespace(client="Teste Cliente", campaign="Campanha Teste", sheet_id="dummy", tabs={})
extractor = WorkingVideoExtractor(config)
extractor.sheets_service.is_configured = lambda: True

def fake_read_tab(tab_key, default):
    if tab_key == "daily_data":
        data = pd.DataFrame([
            {
                "Date": "2024-09-01",
                "Creative": "Video A",
                "Video Starts": 800,
                "100% Video Complete": 600,
                "Impressions": 1200,
                "Spend": 1500.0,
                "Clicks": 120,
                "CTR": 0.1,
            },
            {
                "Date": "2024-09-02",
                "Creative": "Video B",
                "Video Starts": 400,
                "100% Video Complete": 220,
                "Impressions": 700,
                "Spend": 800.0,
                "Clicks": 70,
                "CTR": 0.12,
            },
        ])
        return data
    if tab_key == "contract":
        return pd.DataFrame([
            ["Cliente", "Teste Cliente"],
            ["Campanha", "Campanha Teste"],
            ["Valor Investido", "2300"],
            ["CPV", "0.5"],
            ["Visualizacoes Completas", "820"],
            ["Impressoes Contratadas", "3000"],
            ["Periodo de Veiculacao", "01/09/2024 - 02/09/2024"],
        ])
    if tab_key == "strategies":
        return pd.DataFrame([
            ["Segmentação", "Teste"],
            ["Criativo", "Criativo destaque"],
        ])
    return pd.DataFrame()

extractor._read_tab_dataframe = fake_read_tab
result = extractor.extract_data()
print("Daily data registros:")
for row in result["daily_data"]:
    print(row)
print("\nTotal VTR calculado:", result["total_metrics"]["vtr"])
PY

------
https://chatgpt.com/codex/tasks/task_e_68d5e18cf4cc832396e4b30b3ec58ced