### PR TITLE
Improve numeric thousands heuristic

### DIFF
--- a/static/generator/processors/numeric_parsers.py
+++ b/static/generator/processors/numeric_parsers.py
@@ -79,12 +79,10 @@ def normalise_numeric_string(value: NumericInput) -> Optional[str]:
     treat_as_decimal = bool(decimal_digits)
 
     if treat_as_decimal:
-        if decimal_sep == "." and "," not in unsigned:
-            # Heuristic: patterns like 193.750 are thousands with three trailing digits.
-            if len(decimal_digits) == 3 and len(integer_digits) > 2:
-                treat_as_decimal = False
-        elif decimal_sep == "," and "." not in unsigned:
-            if len(decimal_digits) == 3 and len(integer_digits) > 2:
+        other_separator = "," if decimal_sep == "." else "."
+        if other_separator not in unsigned:
+            # Heuristic: strings like 31.000 or 12.345 represent thousands.
+            if len(decimal_digits) == 3 and len(digits_only) > 3:
                 treat_as_decimal = False
 
     if treat_as_decimal:


### PR DESCRIPTION
## Summary
- refine numeric parser heuristic to treat values like 31.000 and 12.345 as thousands when no alternate separator is present
- ensure both comma and dot separators share the same detection logic

## Testing
- python - <<'PY'
from static.generator.processors.numeric_parsers import safe_float, safe_int

values = ["31.000", "12.345", "1.234,56", "3,142", "42"]
for value in values:
    print(value, '-> float:', safe_float(value), 'int:', safe_int(value))
PY
- python - <<'PY'
import sys, os
sys.path.append(os.path.join(os.getcwd(), 'static/generator/processors'))
from working_video_extractor import WorkingVideoExtractor

extractor = WorkingVideoExtractor.__new__(WorkingVideoExtractor)
print('Contracted impressions:', extractor._safe_int('12.345'))
print('Contracted starts:', extractor._safe_int('31.000'))
print('Contracted investment:', extractor._safe_float('45.678'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d5e298dbc08323ab3069093ecb2a4f