### PR TITLE
Add Unidecode dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ python-dotenv==1.0.0
 requests==2.31.0
 python-dateutil==2.8.2
 schedule==1.2.0
+Unidecode==1.3.6
 
 # Production
 psycopg2-binary==2.9.9  # Para PostgreSQL se necessário


### PR DESCRIPTION
## Summary
- add the Unidecode package to the utilities section of the Python requirements file so it is installed everywhere

## Testing
- `python3 -m venv /tmp/venv`
- `source /tmp/venv/bin/activate`
- `pip install -r requirements.txt`
- `python - <<'PY' import os, sys; sys.path.append(os.path.join(os.path.dirname(__file__), 'static', 'generator', 'processors')); from working_video_extractor import WorkingVideoExtractor; print('Imported WorkingVideoExtractor:', WorkingVideoExtractor) PY`
- `deactivate`


------
https://chatgpt.com/codex/tasks/task_e_68d5ea521948832391cc7a7f6f3456f1