### PR TITLE
Fix zero handling in channel table formatting

### DIFF
--- a/static/generator/templates/dash_generic.html
+++ b/static/generator/templates/dash_generic.html
@@ -706,10 +706,11 @@ class DashboardLoader {
         metricsContainer.innerHTML = cards.join('\n');
 
         const formatCurrencyCell = (value) => {
-            if (!Number.isFinite(value) || value === 0) {
+            if (!Number.isFinite(value)) {
                 return '-';
             }
-            return `R$ ${this.formatCurrency(value)}`;
+            const normalized = Object.is(value, -0) ? 0 : value;
+            return `R$ ${this.formatCurrency(normalized)}`;
         };
 
         const formatNumberCell = (value) => {
@@ -723,10 +724,11 @@ class DashboardLoader {
         };
 
         const formatPercentageCell = (value) => {
-            if (!Number.isFinite(value) || value === 0) {
+            if (!Number.isFinite(value)) {
                 return '-';
             }
-            return this.formatPercentage(value);
+            const normalized = Object.is(value, -0) ? 0 : value;
+            return this.formatPercentage(normalized);
         };
 
         if (rows.length === 0) {


### PR DESCRIPTION
## Summary
- ensure channel daily table currency and percentage helpers show zero values instead of treating them as missing
- keep integer counts formatting unchanged for zero counts

## Testing
- `node - <<'NODE' ...` (renders channel view with zero-investment day and confirms output includes "R$ 0,00" and "0")

------
https://chatgpt.com/codex/tasks/task_e_68d5ed53875c832392a96501fa42fd68