### PR TITLE
Improve channel publisher selection

### DIFF
--- a/static/generator/templates/dash_generic.html
+++ b/static/generator/templates/dash_generic.html
@@ -453,39 +453,63 @@ class DashboardLoader {
             strategies.primary_channel
         );
 
-        if (!this.hasValue(primaryChannel)) {
-            const publishers = Array.isArray(data && data.publishers) ? data.publishers : [];
-            const firstPublisher = publishers.find(publisher => {
-                const label = this.resolveText(
-                    publisher && publisher.name,
-                    publisher && publisher.channel,
-                    publisher && publisher.publisher,
-                    publisher && publisher.label
-                );
-                return this.hasValue(label);
-            });
-            if (firstPublisher) {
-                primaryChannel = this.resolveText(
-                    firstPublisher.name,
-                    firstPublisher.channel,
-                    firstPublisher.publisher,
-                    firstPublisher.label
-                );
+        const publishers = Array.isArray(data && data.publishers) ? data.publishers : [];
+        const normalizedPublishers = publishers.map(publisher => {
+            const label = this.resolveText(
+                publisher && publisher.name,
+                publisher && publisher.channel,
+                publisher && publisher.publisher,
+                publisher && publisher.label
+            );
+            if (!this.hasValue(label)) {
+                return null;
+            }
+            const identifier = this.normalizeIdentifier(
+                (publisher && (publisher.identifier || publisher.id || publisher.slug || publisher.key))
+                    || label
+            );
+            if (publisher && typeof publisher === 'object') {
+                publisher._label = label;
+                publisher._normalizedName = identifier;
+            }
+            return {
+                original: publisher,
+                label,
+                normalized: identifier
+            };
+        }).filter(Boolean);
+
+        let selectedLabel = this.hasValue(primaryChannel) ? primaryChannel : null;
+        let selectedIdentifier = this.normalizeIdentifier(selectedLabel);
+        let selectedPublisher = null;
+
+        if (normalizedPublishers.length) {
+            if (selectedIdentifier) {
+                selectedPublisher = normalizedPublishers.find(item => item.normalized === selectedIdentifier) || null;
+            }
+
+            if (!selectedPublisher) {
+                selectedPublisher = normalizedPublishers[0];
             }
         }
 
-        if (this.hasValue(primaryChannel)) {
-            this.updateText('primary-channel-badge', primaryChannel);
+        if (selectedPublisher) {
+            selectedLabel = selectedPublisher.label;
+            selectedIdentifier = selectedPublisher.normalized;
+        }
+
+        if (this.hasValue(selectedLabel)) {
+            this.updateText('primary-channel-badge', selectedLabel);
             const titleElement = document.getElementById('primary-channel-title');
             if (titleElement) {
-                titleElement.textContent = `Entrega diária — ${primaryChannel}`;
+                titleElement.textContent = `Entrega diária — ${selectedLabel}`;
             }
         }
 
-        this.renderChannelView(data, primaryChannel);
+        this.renderChannelView(data, selectedLabel, selectedIdentifier);
     }
 
-    renderChannelView(data, channelName) {
+    renderChannelView(data, channelName, channelIdentifier) {
         const metricsContainer = document.getElementById('metrics-channel');
         const dailyBody = document.getElementById('channelDailyBody');
         if (!metricsContainer || !dailyBody) {
@@ -498,21 +522,82 @@ class DashboardLoader {
         const publishers = Array.isArray(data && data.publishers) ? data.publishers : [];
         const dailyData = Array.isArray(data && data.daily_data) ? data.daily_data : [];
 
-        const normalizedTarget = typeof channelName === 'string' ? channelName.trim().toLowerCase() : '';
+        const normalizedTarget = this.normalizeIdentifier(channelIdentifier)
+            || this.normalizeIdentifier(channelName);
 
         const publisherMetrics = publishers.find(publisher => {
+            if (!publisher || typeof publisher !== 'object') {
+                return false;
+            }
+            if (!publisher._normalizedName) {
+                const candidate = this.normalizeIdentifier(
+                    publisher.normalized_name
+                        || publisher.identifier
+                        || publisher.id
+                        || publisher.slug
+                        || publisher.key
+                ) || this.normalizeIdentifier(
+                    this.resolveText(
+                        publisher && publisher.name,
+                        publisher && publisher.channel,
+                        publisher && publisher.publisher,
+                        publisher && publisher.label
+                    )
+                );
+                if (candidate) {
+                    publisher._normalizedName = candidate;
+                }
+            }
+            if (publisher._label === undefined) {
+                const label = this.resolveText(
+                    publisher && publisher.name,
+                    publisher && publisher.channel,
+                    publisher && publisher.publisher,
+                    publisher && publisher.label
+                );
+                if (this.hasValue(label)) {
+                    publisher._label = label;
+                }
+            }
             const label = this.resolveText(
                 publisher && publisher.name,
                 publisher && publisher.channel,
                 publisher && publisher.publisher,
                 publisher && publisher.label
             );
-            return typeof label === 'string' && label.trim().toLowerCase() === normalizedTarget;
+            const normalizedLabel = publisher._normalizedName || this.normalizeIdentifier(label);
+            return normalizedTarget && normalizedLabel === normalizedTarget;
         }) || null;
 
         const filterDailyRecord = (record) => {
             if (!normalizedTarget) {
                 return true;
+            }
+            if (record && typeof record === 'object' && !record._normalizedPublisher) {
+                const candidateIdentifier = this.normalizeIdentifier(
+                    record.publisher_identifier
+                        || record.publisher_id
+                        || record.publisher_slug
+                        || record.publisher_key
+                        || record.publisher
+                        || record.site
+                        || record.channel
+                        || record.name
+                );
+                if (candidateIdentifier) {
+                    record._normalizedPublisher = candidateIdentifier;
+                } else {
+                    const fallbackLabel = this.resolveText(
+                        record && record.publisher,
+                        record && record.site,
+                        record && record.channel,
+                        record && record.name
+                    );
+                    record._normalizedPublisher = this.normalizeIdentifier(fallbackLabel);
+                }
+            }
+            if (record && typeof record === 'object' && record._normalizedPublisher) {
+                return record._normalizedPublisher === normalizedTarget;
             }
             const label = this.resolveText(
                 record && record.publisher,
@@ -520,14 +605,12 @@ class DashboardLoader {
                 record && record.channel,
                 record && record.name
             );
-            if (typeof label === 'string' && label.trim().toLowerCase() === normalizedTarget) {
-                return true;
-            }
-            return false;
+            const normalizedLabel = this.normalizeIdentifier(label);
+            return normalizedLabel === normalizedTarget;
         };
 
-        const filteredDaily = dailyData.filter(filterDailyRecord);
-        const dailyRecords = filteredDaily.length ? filteredDaily : dailyData;
+        const filteredDaily = normalizedTarget ? dailyData.filter(filterDailyRecord) : dailyData;
+        const dailyRecords = normalizedTarget ? filteredDaily : dailyData;
 
         const totals = {
             spend: 0,
@@ -733,7 +816,10 @@ class DashboardLoader {
         };
 
         if (rows.length === 0) {
-            dailyBody.innerHTML = '<tr><td colspan="9" class="muted">Sem dados diários disponíveis</td></tr>';
+            const emptyMessage = normalizedTarget
+                ? 'Sem dados para este canal'
+                : 'Sem dados diários disponíveis';
+            dailyBody.innerHTML = `<tr><td colspan="9" class="muted">${emptyMessage}</td></tr>`;
             return;
         }
 
@@ -1144,6 +1230,20 @@ class DashboardLoader {
             }
         }
         return null;
+    }
+
+    normalizeIdentifier(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        const text = String(value).trim();
+        if (!text) {
+            return '';
+        }
+        return text
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase();
     }
 
     hasValue(value) {


### PR DESCRIPTION
## Summary
- normalize publisher identifiers when selecting the primary channel and persist the chosen label
- pass the normalized identifier to the channel renderer so daily data is filtered strictly and show an empty message when nothing matches
- add a helper for identifier normalization reused across publishers and daily rows

## Testing
- node - <<'NODE' \nconst fs = require('fs');\nconst vm = require('vm');\nconst html = fs.readFileSync('static/generator/templates/dash_generic.html', 'utf8');\nconst scriptMatch = html.match(/<script>([\\s\\S]*)<\\/script>/);\nlet scriptContent = scriptMatch[1];\nscriptContent += '\\nthis.DashboardLoader = DashboardLoader;';\nconst elements = new Map();\nconst createElement = (id) => {\n  const store = { id, textContent: '', _innerHTML: '' };\n  Object.defineProperty(store, 'innerHTML', {\n    get() { return this._innerHTML; },\n    set(value) { this._innerHTML = value; }\n  });\n  elements.set(id, store);\n  return store;\n};\n['primary-channel-badge', 'primary-channel-title', 'metrics-channel', 'channelDailyBody'].forEach(createElement);\nconst documentStub = {\n  elements,\n  getElementById(id) { return elements.get(id) || null; },\n  addEventListener() { /* ignore */ }\n};\nconst sandbox = {\n  console,\n  document: documentStub,\n  window: {},\n  fetch: async () => { throw new Error('fetch not implemented in test'); }\n};\nvm.createContext(sandbox);\nvm.runInContext(scriptContent, sandbox);\nconst DashboardLoader = sandbox.DashboardLoader || sandbox.window.DashboardLoader;\nif (!DashboardLoader) {\n  throw new Error('DashboardLoader not available');\n}\nconst loader = new DashboardLoader('test');\nconst testData = {\n  contract: {\n    client: 'Cliente X',\n    campaign: 'Campanha Y',\n    channel: 'Prográmatica'\n  },\n  strategies: {},\n  channel: 'Prográmatica',\n  publishers: [\n    { name: 'Publisher Á' },\n    { name: 'Publisher B' },\n    { name: 'Publisher C' }\n  ],\n  daily_data: [\n    {\n      date: '2025-09-17',\n      publisher: 'Publisher Á',\n      spend: 100,\n      impressions: 1000,\n      clicks: 20,\n      starts: 900,\n      q100: 600\n    },\n    {\n      date: '2025-09-18',\n      publisher: 'Publisher B',\n      spend: 200,\n      impressions: 1500,\n      clicks: 30,\n      starts: 1200,\n      q100: 900\n    },\n    {\n      date: '2025-09-19',\n      publisher: 'Publisher C',\n      spend: 300,\n      impressions: 2000,\n      clicks: 40,\n      starts: 1500,\n      q100: 1100\n    }\n  ]\n};\nloader.renderChannelsSection(testData);\nconst badge = elements.get('primary-channel-badge').textContent;\nconst title = elements.get('primary-channel-title').textContent;\nconst rowsHtml = elements.get('channelDailyBody').innerHTML;\nconst rowCount = (rowsHtml.match(/<tr>/g) || []).length;\nconsole.log({ badge, title, rowCount, rowsHtml });\nNODE

------
https://chatgpt.com/codex/tasks/task_e_68d5f53b414c8323a79c33146c15e06a